### PR TITLE
Loop until no more Exceptions

### DIFF
--- a/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/StandardBatchInsert.java
+++ b/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/StandardBatchInsert.java
@@ -86,8 +86,14 @@ public class StandardBatchInsert
             logger.info(String.format("> %.2f seconds (loaded %,d rows in total)", seconds, totalRows));
 
         } catch (BatchUpdateException e) {
-            // Output the exception message further to provide a detailed cause.
-            logger.error(e.getNextException().getMessage());
+            SQLException ex = e.getNextException();
+
+            while (ex != null) {
+                // Output the exception message further to provide a detailed cause.
+                logger.error(ex.getMessage());
+                ex = ex.getNextException();
+            }
+
             // will be used for retry
             lastUpdateCounts = e.getUpdateCounts();
             throw e;


### PR DESCRIPTION
It was mentioned in the official documentation

> 5. In a loop, execute the getMessage, getSQLState, getErrorCode, and getNextException method calls to obtain information about an SQLException and get the next SQLException.
https://www.ibm.com/docs/en/db2/11.5?topic=sqlj-retrieving-information-from-batchupdateexception

```java
try {
  // Batch updates
} catch(BatchUpdateException buex) {
    System.err.println("Contents of BatchUpdateException:");
    System.err.println(" Update counts: ");
    int [] updateCounts = buex.getUpdateCounts();             1 
    for (int i = 0; i < updateCounts.length; i++) {
      System.err.println("  Statement " + i + ":" + updateCounts[i]);
    }
    ResultSet[] resultList = 
      ((DBBatchUpdateException)buex).getDBGeneratedKeys();    2 
    for (i = 0; i < resultList.length; i++)
    {
      if (resultList[i] == null)
         continue; // Skip the ResultSet for which there was a failure
      else {
        rs.next();
        java.math.BigDecimal idColVar = rs.getBigDecimal(1);     
                                      // Get automatically generated key 
                                      // value
        System.out.println("Automatically generated key value = " + idColVar);
      }
    }
    System.err.println(" Message: " + buex.getMessage());     3 
    System.err.println(" SQLSTATE: " + buex.getSQLState());
    System.err.println(" Error code: " + buex.getErrorCode());
    SQLException ex = buex.getNextException();                4 
    while (ex != null) {                                      5 
      System.err.println("SQL exception:");
      System.err.println(" Message: " + ex.getMessage());
      System.err.println(" SQLSTATE: " + ex.getSQLState());
      System.err.println(" Error code: " + ex.getErrorCode());
      ex = ex.getNextException();
    }
}
```